### PR TITLE
Add errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,16 @@ class BlindPeerError extends Error {
     return new BlindPeerError('Mailbox not found', 'MAILBOX_NOT_FOUND', BlindPeerError.MAILBOX_NOT_FOUND)
   }
 
+  static INVALID_MAILBOX_ID () {
+    return new BlindPeerError('Invalid mailbox id', 'INVALID_MAILBOX_ID', BlindPeerError.INVALID_MAILBOX_ID)
+  }
+
   static fromRpcCause (cause) {
     switch (cause.code) {
       case 'MAILBOX_NOT_FOUND':
         return BlindPeerError.MAILBOX_NOT_FOUND(cause.message)
+      case 'INVALID_MAILBOX_ID':
+        return BlindPeerError.INVALID_MAILBOX_ID(cause.message)
       default:
         throw new BlindPeerError(cause.message)
     }

--- a/index.js
+++ b/index.js
@@ -12,9 +12,38 @@ const postEncoding = {
   responseEncoding: c.none
 }
 
+class BlindPeerError extends Error {
+  constructor (msg, code, fn = BlindPeerError) {
+    super(`${code}: ${msg}`)
+    this.code = code
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, fn)
+    }
+  }
+
+  get name () {
+    return 'BlindPeerError'
+  }
+
+  static MAILBOX_NOT_FOUND () {
+    return new BlindPeerError('Mailbox not found', 'MAILBOX_NOT_FOUND', BlindPeerError.MAILBOX_NOT_FOUND)
+  }
+
+  static fromRpcCause (cause) {
+    switch (cause.code) {
+      case 'MAILBOX_NOT_FOUND':
+        return BlindPeerError.MAILBOX_NOT_FOUND(cause.message)
+      default:
+        throw new BlindPeerError(cause.message)
+    }
+  }
+}
+
 module.exports = {
   definition,
   schema,
   addMailboxEncoding,
-  postEncoding
+  postEncoding,
+  BlindPeerError
 }


### PR DESCRIPTION
The idea is to allow the client to transform RPC errors back to normal errors, with error codes indicating what went wrong, so the client can take the correct action for expected error codes (either pass them on to the user, such as 'UNKNOWN_MAILBOX_ID' errors, or with side effects such as to temporarily stop sending requests if it receives a TOO_MANY_REQUESTS error).

Protomux-rpc now includes the cause field to pass the original error for REQUEST_ERRORs, which includes a `code` and `message` field, allowing structured error handling.

This logic needs to be shared between client and server, just like the encodings, hence the idea of adding them here.
