### PR TITLE
Use hyperdb v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "compact-encoding": "^2.16.0",
-    "hyperdb": "^5.0.0"
+    "hyperdb": "^6.0.0"
   }
 }


### PR DESCRIPTION
We also need to update the schemas of the blind-peer encodings, but I'm keeping that for a separate PR as it's slightly more risky: https://github.com/holepunchto/blind-peer-encodings/pull/14 (all changes there are from v4-v5, because the original encodings were never updated to v5)